### PR TITLE
Added instructions for Arch Linux and Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ This is a [Strawpoll](http://strawpoll.me/) Vote Bot. You will need to have PHP5
 3. Restart Apache:
 
     `sudo /etc/init.d/apache2 restart`
+
+**Arch Linux**
+
+Install PHP:
+
+    sudo pacman -S php
+
+**Fedora**
+
+1. Install PHP:
+
+    `sudo dnf install php`
+
+2. Install php-xml:
+
+    `sudo dnf install php-xml`
     
 **Other**
 


### PR DESCRIPTION
Curl is bundled with the PHP package on Arch Linux/Fedora, so that is not needed to be installed separately.
Fedora has to have php-xml installed to work, otherwise DOMDocument class will not be found.
